### PR TITLE
Use jackson-core (2.13.1) libraries from dao-node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,11 @@ dependencies {
 
     implementation 'bisq:assets'
     implementation 'bisq:common'
-    implementation 'bisq:core'
+    implementation('bisq:core') {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
     implementation 'bisq:p2p'
 
     implementation libs.chimp.jsocks

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -6,8 +6,9 @@ dependencies {
     constraints {
         api 'org.apache.commons:commons-lang3:3.11'
 
-        api 'com.fasterxml.jackson.core:jackson-annotations:2.12.1'
-        api 'com.fasterxml.jackson.core:jackson-core:2.12.1'
-        api 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+        api 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+        api 'com.fasterxml.jackson.core:jackson-core:2.13.1'
+        api 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+        api 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.12.7'
     }
 }


### PR DESCRIPTION
Glassfish depends on features of a newer jackson library. Thus, we cannot use the ones from the main Bisq project.